### PR TITLE
PERFREPO-236: Client side url construction and test execution building

### DIFF
--- a/client/src/main/java/org/perfrepo/client/PerfRepoClient.java
+++ b/client/src/main/java/org/perfrepo/client/PerfRepoClient.java
@@ -109,7 +109,7 @@ public class PerfRepoClient {
    }
 
    private String restUrl(String urlTemplate, Object... params) {
-      return String.format(String.format(REST_BASE_URL_TEMPLATE, host, url) + urlTemplate, params);
+      return String.format(String.format(REST_BASE_URL_TEMPLATE, host, url == null ? "" : url) + urlTemplate, params);
    }
 
    private void logHttpError(String msg, HttpRequestBase req, HttpResponse resp) throws Exception {

--- a/model/src/main/java/org/perfrepo/model/builder/TestExecutionBuilder.java
+++ b/model/src/main/java/org/perfrepo/model/builder/TestExecutionBuilder.java
@@ -90,8 +90,25 @@ public class TestExecutionBuilder {
          parameters = new ArrayList<TestExecutionParameter>();
          testExecution.setParameters(parameters);
       }
-      parameters.add(param);
+      TestExecutionParameter existingParameter = findParameter(param.getName());
+      if (existingParameter != null) {
+         existingParameter.setValue(param.getValue());
+      } else {
+         parameters.add(param);
+      }
       return param;
+   }
+
+   private TestExecutionParameter findParameter(String name) {
+      if (testExecution == null || testExecution.getParameters() == null || name == null) {
+         return null;
+      }
+      for (TestExecutionParameter param : testExecution.getParameters()) {
+         if (name.equals(param.getName())) {
+            return param;
+         }
+      }
+      return null;
    }
 
    private TestExecutionParameter addParameter(String name, String value) {


### PR DESCRIPTION
These changes were needed for us to use PerfRepo in production, please consider accepting to upstream.

PerfRepoClient.java
This was problem when we deployed perfrepo war to http server's root context.

TestExecutionBuilder.java
Sometimes we want to override already created parameter in test execution builder. Also builder can already validate whether we've unique parameter names or not by forcing them to be unique on client side
